### PR TITLE
Add time remaining in raid command

### DIFF
--- a/mod_bot/main.py
+++ b/mod_bot/main.py
@@ -21,6 +21,7 @@ client = discord.Client()
 is_connected = False
 
 MAX_MESSAGE_SIZE = 2000
+paris_tz = pytz.timezone('Europe/Paris')
 
 ddb_list = {'timeouts': {}, 'messages':{}}
 
@@ -126,7 +127,7 @@ LIST pour avoir la liste des arènes reconnues'''
                 gym_data = gym_data[0]
 
             raid_hour = words[-1]
-            message_creation_date_localtz = pytz.utc.localize(message.created_at).astimezone(pytz.timezone('Europe/Paris'))
+            message_creation_date_localtz = pytz.utc.localize(message.created_at).astimezone(paris_tz)
             starttime, endtime = get_raid_hours(raid_hour, int(conf['raid_duration']), message_creation_date_localtz)
             if starttime is None or endtime is None:
                 message_to_send += 'Heure "{0}" incorrecte (format 10:30, 10h30,' \

--- a/mod_bot/main.py
+++ b/mod_bot/main.py
@@ -7,7 +7,6 @@ import datetime
 import json
 import os
 import pickle
-import re
 import time
 
 import discord
@@ -16,7 +15,7 @@ import pytz
 import roulette
 from gym import load_gyms, get_approx_name
 
-from raid import clean_raid_command
+from raid import clean_raid_command, get_raid_hours
 
 client = discord.Client()
 is_connected = False
@@ -126,31 +125,17 @@ LIST pour avoir la liste des arènes reconnues'''
             else:
                 gym_data = gym_data[0]
 
-            if isOk is True:
-                hour_pattern = re.compile("@*((0*[0-9])|(1[0-9])|(2[0-3]))[:hH]([0-5][0-9])")
-                end_hour = words[-1]
-                m = hour_pattern.match(end_hour)
-                if m is None:
-                    message_to_send += 'Heure "{0}" incorrecte (format 10:30, 10h30, ou @10h30)'.format(end_hour)
-                    isOk = False
+            raid_hour = words[-1]
+            message_creation_date_localtz = pytz.utc.localize(message.created_at).astimezone(pytz.timezone('Europe/Paris'))
+            starttime, endtime = get_raid_hours(raid_hour, int(conf['raid_duration']), message_creation_date_localtz)
+            if starttime is None or endtime is None:
+                message_to_send += 'Heure "{0}" incorrecte (format 10:30, 10h30,' \
+                                   ' ou @10h30, ou 30, 30mn, 30min, 30minutes)'.format(raid_hour)
+                isOk = False
 
             if isOk is True:
-                end_hour = end_hour.replace(':', 'h').lower()
-                h = end_hour.replace('@', '').split('h')[0]
-                if end_hour[0] == '@':
-                    # Heure de pop, calcule l'heure de fin
-                    pop_hour = ('0' if int(h) < 10 and len(h) < 2 else '') + end_hour[1:]
-                    hend = int(pop_hour.split('h')[0])
-                    mend = int(pop_hour.split('h')[1])
-                    endtime = add_minutes(hend, mend, int(conf["raid_duration"]))
-                    end_hour = "{0:02d}h{1:02d}".format(endtime[0], endtime[1])
-                else:
-                    end_hour = ('0' if int(h) < 10 and len(h) < 2 else '') + end_hour
-                    hend = int(end_hour.split('h')[0])
-                    mend = int(end_hour.split('h')[1])
-                    starttime = add_minutes(hend, mend, -int(conf["raid_duration"]))
-                    pop_hour = "{0:02d}h{1:02d}".format(starttime[0], starttime[1])
-
+                pop_hour = starttime.strftime('%Hh%M')
+                end_hour = endtime.strftime('%Hh%M')
                 should_delete = False
                 channel_name = "{0}-{1}-fin{2}".format(poke, gym_data[0], end_hour)
 

--- a/mod_bot/main.py
+++ b/mod_bot/main.py
@@ -114,13 +114,13 @@ LIST pour avoir la liste des arènes reconnues'''
             elif len(gym_data) > 10:
                 message_to_send = "L'arène n'a pas pu être trouvée\n"
                 message_to_send += "La requête n'est pas assez spécifique, {0} résultats possibles\n".format(len(gym_data))
-                message_to_send += "Veuillez préciser votre recherche, utilisez `LIST` pour trouver votre arène"
+                message_to_send += "Veuillez préciser votre recherche, utilisez `LIST` pour trouver votre arène\n"
                 isOk = False
                 should_delete = False
             elif len(gym_data) >= 2:
                 message_to_send = "L'arène n'a pas pu être trouvée\n"
                 message_to_send += "Vouliez vous dire l'un des choix suivants?\n"
-                message_to_send += ", ".join(map(lambda x: x[1], gym_data))
+                message_to_send += ", ".join(map(lambda x: x[1], gym_data)) + "\n"
                 isOk = False
                 should_delete = False
             else:
@@ -130,8 +130,8 @@ LIST pour avoir la liste des arènes reconnues'''
             message_creation_date_localtz = pytz.utc.localize(message.created_at).astimezone(paris_tz)
             starttime, endtime = get_raid_hours(raid_hour, int(conf['raid_duration']), message_creation_date_localtz)
             if starttime is None or endtime is None:
-                message_to_send += 'Heure "{0}" incorrecte (format 10:30, 10h30,' \
-                                   ' ou @10h30, ou 30, 30mn, 30min, 30minutes)'.format(raid_hour)
+                message_to_send += 'Heure "{0}" incorrecte, formats possibles: 10:30, 10h30,' \
+                                   ' @10h30, 30mn, 30min, 30minutes)\n'.format(raid_hour)
                 isOk = False
 
             if isOk is True:

--- a/mod_bot/raid.py
+++ b/mod_bot/raid.py
@@ -1,7 +1,24 @@
 from datetime import datetime
 from datetime import timedelta
+import re
 
-raid_date_format = ['%Hh%M', '@%Hh%M', '%M', '%Mmn', '%Mmin', '%Mminutes']
+raid_date_format = [
+    {
+        'format': '%Hh%M',
+        'is_at_time': False
+    }, {
+        'format': '@%Hh%M',
+        'is_at_time': True
+    }, {
+        'format': '%H:%M',
+        'is_at_time': False
+    }, {
+        'format': '@%H:%M',
+        'is_at_time': True
+    }
+]
+
+minutes_regex = "\d+"
 
 
 def get_raid_hours(time, raid_duration, message_date):
@@ -15,37 +32,49 @@ def get_raid_hours(time, raid_duration, message_date):
     :param message_date: time the raid command was issued
     :return: starttime: time, endtime: time
     """
-
-    is_at_time = '@' in time
-    is_minutes_time = 'h' not in time
-
-    raid_time = try_parsing_date(time)
+    raid_time, is_at_time = try_parsing_date(time)
 
     if raid_time is None:
-        return None
+        minutes = int(parse_minutes(time))
+        if minutes is not None:
+            endtime = message_date + timedelta(minutes=minutes)
+            return message_date.time(), endtime.time()
+        else:
+            return None
 
     if is_at_time:
         starttime = raid_time
         endtime = raid_time + timedelta(minutes=raid_duration)
     else:
-        if is_minutes_time:
-            minutes = raid_time.minute
-            starttime = message_date
-            endtime = message_date + timedelta(minutes=minutes)
-        else:  # Todo: might be not useful with the minutes remaining command
-            starttime = raid_time - timedelta(minutes=raid_duration)
-            endtime = raid_time
+        # Todo: might be not useful with the minutes remaining command
+        starttime = message_date
+        endtime = raid_time
 
     return starttime.time(), endtime.time()
 
 
-def try_parsing_date(text):
+def try_parsing_date(raid_command):
     for fmt in raid_date_format:
         try:
-            return datetime.strptime(text, fmt)
+            return datetime.strptime(raid_command, fmt['format']), fmt['is_at_time']
         except ValueError:
             pass
-    return None
+    return None, None
+
+
+def parse_minutes(raid_command):
+    """
+    Because we use match, it works only if the string starts with a number
+    :return: minutes as an integer
+    """
+    matcher = re.match(minutes_regex, raid_command)
+    if matcher is None:
+        return None
+    minutes = int(matcher.group(0))
+    if minutes > 0:
+        return minutes
+    else:
+        return None
 
 
 def clean_raid_command(command):

--- a/mod_bot/raid.py
+++ b/mod_bot/raid.py
@@ -18,7 +18,7 @@ raid_date_format = [
     }
 ]
 
-minutes_regex = "\d+"
+minutes_regex = "\d+(mn|min|minutes)"
 
 
 def get_raid_hours(time, raid_duration, message_date):
@@ -35,12 +35,12 @@ def get_raid_hours(time, raid_duration, message_date):
     raid_time, is_at_time = try_parsing_date(time)
 
     if raid_time is None:
-        minutes = int(parse_minutes(time))
+        minutes = parse_minutes(time)
         if minutes is not None:
             endtime = message_date + timedelta(minutes=minutes)
             return (endtime - timedelta(minutes=raid_duration)).time(), endtime.time()
         else:
-            return None
+            return None, None
 
     if is_at_time:
         starttime = raid_time
@@ -70,7 +70,7 @@ def parse_minutes(raid_command):
     matcher = re.match(minutes_regex, raid_command)
     if matcher is None:
         return None
-    minutes = int(matcher.group(0))
+    minutes = int(re.match("\d+", matcher.group(0)).group(0))
     if minutes > 0:
         return minutes
     else:

--- a/mod_bot/raid.py
+++ b/mod_bot/raid.py
@@ -38,7 +38,7 @@ def get_raid_hours(time, raid_duration, message_date):
         minutes = int(parse_minutes(time))
         if minutes is not None:
             endtime = message_date + timedelta(minutes=minutes)
-            return message_date.time(), endtime.time()
+            return (endtime - timedelta(minutes=raid_duration)).time(), endtime.time()
         else:
             return None
 
@@ -47,7 +47,7 @@ def get_raid_hours(time, raid_duration, message_date):
         endtime = raid_time + timedelta(minutes=raid_duration)
     else:
         # Todo: might be not useful with the minutes remaining command
-        starttime = message_date
+        starttime = raid_time - timedelta(minutes=raid_duration)
         endtime = raid_time
 
     return starttime.time(), endtime.time()

--- a/mod_bot/raid.py
+++ b/mod_bot/raid.py
@@ -1,3 +1,53 @@
+from datetime import datetime
+from datetime import timedelta
+
+raid_date_format = ['%Hh%M', '@%Hh%M', '%M', '%Mmn', '%Mmin', '%Mminutes']
+
+
+def get_raid_hours(time, raid_duration, message_date):
+    """
+    Raid hour can be declare in 3 different ways:
+    - @hh:mm|@h:mm raid starts at the given hour
+    - hh:mm|h:mm raid ends at the given hour
+    - mm|m raid ends in m|mm minutes
+    :param time: hour or duration
+    :param raid_duration: duration of a raid in minutes
+    :param message_date: time the raid command was issued
+    :return: starttime: time, endtime: time
+    """
+
+    is_at_time = '@' in time
+    is_minutes_time = 'h' not in time
+
+    raid_time = try_parsing_date(time)
+
+    if raid_time is None:
+        return None
+
+    if is_at_time:
+        starttime = raid_time
+        endtime = raid_time + timedelta(minutes=raid_duration)
+    else:
+        if is_minutes_time:
+            minutes = raid_time.minute
+            starttime = message_date
+            endtime = message_date + timedelta(minutes=minutes)
+        else:  # Todo: might be not useful with the minutes remaining command
+            starttime = raid_time - timedelta(minutes=raid_duration)
+            endtime = raid_time
+
+    return starttime.time(), endtime.time()
+
+
+def try_parsing_date(text):
+    for fmt in raid_date_format:
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            pass
+    return None
+
+
 def clean_raid_command(command):
     """
     - Remove empty parts

--- a/test/test_raid_creation.py
+++ b/test/test_raid_creation.py
@@ -45,7 +45,7 @@ class TestRaidCreation(unittest.TestCase):
         hour = "42"
         end_time = (now + timedelta(minutes=42)).time()
         start_time = (now + timedelta(minutes=32)).time()
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (start_time, end_time), "no suffix")
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (None, None), "no suffix")
         hour = "42mn"
         self.assertEqual(raid.get_raid_hours(hour, 10, now), (start_time, end_time), "mn")
         hour = "42min"
@@ -69,7 +69,7 @@ class TestRaidCreation(unittest.TestCase):
 
     def test_parse_minutes(self):
         minutes = "42"
-        self.assertEqual(raid.parse_minutes(minutes), 42)
+        self.assertEqual(raid.parse_minutes(minutes), None)
         minutes = "42mn"
         self.assertEqual(raid.parse_minutes(minutes), 42)
         minutes = "42min"
@@ -78,5 +78,7 @@ class TestRaidCreation(unittest.TestCase):
         self.assertEqual(raid.parse_minutes(minutes), 42)
         minutes = "-10"
         self.assertEqual(raid.parse_minutes(minutes), None)
-        minutes = "70"
+        minutes = "70min"
         self.assertEqual(raid.parse_minutes(minutes), 70)
+        minutes = "70sausages"
+        self.assertEqual(raid.parse_minutes(minutes), None, "can't put sausages in the mix")

--- a/test/test_raid_creation.py
+++ b/test/test_raid_creation.py
@@ -37,20 +37,21 @@ class TestRaidCreation(unittest.TestCase):
 
     def test_raid_end_time(self):
         hour = "20h45"
-        self.assertEqual(raid.get_raid_hours(hour, 45, now), (now.time(), time(20, 45)))
+        self.assertEqual(raid.get_raid_hours(hour, 45, now), (time(20, 0), time(20, 45)))
         hour = "9h22"
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (now.time(), time(9, 22)))
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (time(9, 12), time(9, 22)))
         hour = "9:22"
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (now.time(), time(9, 22)))
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (time(9, 12), time(9, 22)))
         hour = "42"
         end_time = (now + timedelta(minutes=42)).time()
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (now.time(), end_time), "no suffix")
+        start_time = (now + timedelta(minutes=32)).time()
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (start_time, end_time), "no suffix")
         hour = "42mn"
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (now.time(), end_time), "mn")
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (start_time, end_time), "mn")
         hour = "42min"
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (now.time(), end_time), "min")
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (start_time, end_time), "min")
         hour = "42minutes"
-        self.assertEqual(raid.get_raid_hours(hour, 10, now), (now.time(), end_time), "minutes")
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (start_time, end_time), "minutes")
 
     def test_format_date_hour(self):
         hours = "10h11"

--- a/test/test_raid_creation.py
+++ b/test/test_raid_creation.py
@@ -1,22 +1,59 @@
 import unittest
 
-from mod_bot.raid import clean_raid_command, clean_empty_parts, fix_lone_at_sign, fix_lone_exclamation_sign
+from mod_bot import raid
+from datetime import time
+from datetime import datetime
+import pytz
 
 
 class TestRaidCreation(unittest.TestCase):
+    global now
+    now = datetime.now(pytz.timezone('Europe/Paris'))
 
     def test_clean_spaces(self):
         words = ["!raid", " ", "egg5", "arena", "@20h00"]
-        self.assertEqual(clean_empty_parts(words), ["!raid", "egg5", "arena", "@20h00"])
+        self.assertEqual(raid.clean_empty_parts(words), ["!raid", "egg5", "arena", "@20h00"])
 
     def test_fix_lone_at_sign(self):
         words = ["!raid", " ", "egg5", "arena", "@", "20h00"]
-        self.assertEqual(fix_lone_at_sign(words), ["!raid", " ", "egg5", "arena", "@20h00"])
+        self.assertEqual(raid.fix_lone_at_sign(words), ["!raid", " ", "egg5", "arena", "@20h00"])
 
     def test_fix_lone_exclamation_sign(self):
         words = ["!", "raid", " ", "egg5", "arena", "@20h00"]
-        self.assertEqual(fix_lone_exclamation_sign(words), ["!raid", " ", "egg5", "arena", "@20h00"])
+        self.assertEqual(raid.fix_lone_exclamation_sign(words), ["!raid", " ", "egg5", "arena", "@20h00"])
 
     def test_clean_raid_command(self):
         words = ["!", "raid", "", "egg5", "arena", "@", "20h00"]
-        self.assertEqual(clean_raid_command(words), ["!raid", "egg5", "arena", "@20h00"])
+        self.assertEqual(raid.clean_raid_command(words), ["!raid", "egg5", "arena", "@20h00"])
+
+    def test_raid_at_time(self):
+        hour = "@20h00"
+        self.assertEqual(raid.get_raid_hours(hour, 45, now), (time(20, 0), time(20, 45)))
+        hour = "@9h12"
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (time(9, 12), time(9, 22)))
+
+    def test_raid_end_time(self):
+        hour = "20h45"
+        self.assertEqual(raid.get_raid_hours(hour, 45, now), (time(20, 0), time(20, 45)))
+        hour = "9h22"
+        self.assertEqual(raid.get_raid_hours(hour, 10, now), (time(9, 12), time(9, 22)))
+
+    def test_format_date_minutes(self):
+        minutes = "43"
+        self.assertEqual(raid.try_parsing_date(minutes).time(), time(0, 43))
+        minutes = "43mn"
+        self.assertEqual(raid.try_parsing_date(minutes).time(), time(0, 43))
+        minutes = "43min"
+        self.assertEqual(raid.try_parsing_date(minutes).time(), time(0, 43))
+        minutes = "43minutes"
+        self.assertEqual(raid.try_parsing_date(minutes).time(), time(0, 43))
+        minutes = "-10"
+        self.assertEqual(raid.try_parsing_date(minutes), None)
+        minutes = "70"  # TODO: Should work for events
+        self.assertEqual(raid.try_parsing_date(minutes), None)
+
+    def test_format_date_hour(self):
+        hours = "10h11"
+        self.assertEqual(raid.try_parsing_date(hours).time(), time(10, 11))
+        hours = "@10h11"
+        self.assertEqual(raid.try_parsing_date(hours).time(), time(10, 11))


### PR DESCRIPTION
#9 : implement time remaining in the form of a minutes remaining.

Issues remaining:  
* Cannot have more then 59 minutes remaining
* Not ideal, datetime/time lib are not easy to deal with in python